### PR TITLE
More robust packaging

### DIFF
--- a/arcpy_metadata/__init__.py
+++ b/arcpy_metadata/__init__.py
@@ -1,14 +1,12 @@
 from __future__ import print_function
 
-__version__ = '0.3.1'
-__author__ = 'nickrsan, thomas.maschler'
-
 import xml
 import os
 import xml.etree.ElementTree as ET
 
 import arcpy
 
+from version import *
 from metadata_items import *
 
 

--- a/arcpy_metadata/version.py
+++ b/arcpy_metadata/version.py
@@ -1,0 +1,2 @@
+__version__ = '0.3.1'
+__author__ = 'nickrsan, thomas.maschler'

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 
 with open('arcpy_metadata/version.py') as fin: exec(fin.read())
 

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,9 @@
-__author__ = 'nickrsan'
-from arcpy_metadata import __version__ as meta_version
-
 from distutils.core import setup
 
+with open('arcpy_metadata/version.py') as fin: exec(fin.read())
+
 setup(name="arcpy_metadata",
-	version=meta_version,
+	version=__version__,
 	description="Python metadata editing classes for ArcGIS feature classes",
 	#scripts=[],
 	packages=['arcpy_metadata',],


### PR DESCRIPTION
Two changes:

1. Remove the need to import the package to build the package (pip install arcpy_metadata didn't work for me because my build virtualenv doesn't have arcpy in it (but my run venv does, so the package will work when I'm actually using it), other situations would also run into this problem).

2. Using setuptools instead of distutils so that I can build a wheel. Wheels are just better ;-) I made this a separate commit in case you would not like the extra dependency on setuptools for building your package.

Cheers,

Adam