### PR TITLE
Update for Supported Items table, and spelling in elements.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Supported items
 |Citation Contacts|citation_contact|ContactObj|Overview/ Citation Contact/ Contact/|dataIdInfo/idCitation/citRespParty|
 |Language|language|String|Resource/ Detail/ Languages/ Language|dataIdInfo/dataLang|
 |Metadata Language|metadata_language|String|Metadata/ Detail/ Language|dataIdInfo/mdLang|
-|Alternative Title|alternative_title|String|Overview/Citation/Titles/Alternate Title|dataIdInfo/idCitation/resAltTitle|
+|Alternate Title|alternate_title|String|Overview/Citation/Titles/Alternate Title|dataIdInfo/idCitation/resAltTitle|
 |Identifier Code (1)|identifier_code1|String|Overview/Citation/Identifier/Code|dataIdInfo/idCitation/citId/identCode|
 |Identifier Code (2)|identifier_code2|String|Overview/Citation/Identifier/Authority Citation/Identifier/Code|dataIdInfo/idCitation/citId/identAuth/citId/identCode|
 |Identifier Code (3)|identifier_code3|String|Overview/Citation/Identifier/Authority Citation/Identifier/Authority Citation/Identifier/Code|dataIdInfo/idCitation/citId/identAuth/citId/identAuth/citId/identCode|

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Supported items
 |Citation Contacts|citation_contact|ContactObj|Overview/ Citation Contact/ Contact/|dataIdInfo/idCitation/citRespParty|
 |Language|language|String|Resource/ Detail/ Languages/ Language|dataIdInfo/dataLang|
 |Metadata Language|metadata_language|String|Metadata/ Detail/ Language|dataIdInfo/mdLang|
-|Alternateive Title|alternative_title|String|Overview/Citation/Titles/Alternate Title|dataIdInfo/idCitation/resAltTitle|
+|Alternative Title|alternative_title|String|Overview/Citation/Titles/Alternate Title|dataIdInfo/idCitation/resAltTitle|
 |Identifier Code (1)|identifier_code1|String|Overview/Citation/Identifier/Code|dataIdInfo/idCitation/citId/identCode|
 |Identifier Code (2)|identifier_code2|String|Overview/Citation/Identifier/Authority Citation/Identifier/Code|dataIdInfo/idCitation/citId/identAuth/citId/identCode|
 |Identifier Code (3)|identifier_code3|String|Overview/Citation/Identifier/Authority Citation/Identifier/Authority Citation/Identifier/Code|dataIdInfo/idCitation/citId/identAuth/citId/identAuth/citId/identCode|

--- a/README.md
+++ b/README.md
@@ -137,6 +137,14 @@ Supported items
 |Citation Contacts|citation_contact|ContactObj|Overview/ Citation Contact/ Contact/|dataIdInfo/idCitation/citRespParty|
 |Language|language|String|Resource/ Detail/ Languages/ Language|dataIdInfo/dataLang|
 |Metadata Language|metadata_language|String|Metadata/ Detail/ Language|dataIdInfo/mdLang|
+|Alternateive Title|alternative_title|String|Overview/Citation/Titles/Alternate Title|dataIdInfo/idCitation/resAltTitle|
+|Identifier Code (1)|identifier_code1|String|Overview/Citation/Identifier/Code|dataIdInfo/idCitation/citId/identCode|
+|Identifier Code (2)|identifier_code2|String|Overview/Citation/Identifier/Authority Citation/Identifier/Code|dataIdInfo/idCitation/citId/identAuth/citId/identCode|
+|Identifier Code (3)|identifier_code3|String|Overview/Citation/Identifier/Authority Citation/Identifier/Authority Citation/Identifier/Code|dataIdInfo/idCitation/citId/identAuth/citId/identAuth/citId/identCode|
+|Identifier Code (4)|identifier_code4|String|Resource/Lineage/Data Source/Reference System/Authority Citation/Identifier/Code|dqInfo/dataLineage/dataSource/srcRefSys/identAuth/citId/identCode|
+|Metadata File Identifier|file_identifier|String|Metadata/Details/File Idnetifier|mdFileID|
+|Dataset URI|dataset_uri|String|Metadata/Details/Dataset URI|dataSetURI|
+|Resource Label|resource_label|String|Resource/Fields/Details/Label|eainfo/detailed/enttyp/enttypl|
 
 Contact items
 ---------------

--- a/arcpy_metadata/elements.py
+++ b/arcpy_metadata/elements.py
@@ -6,7 +6,7 @@ elements = {
                 "path": "dataIdInfo/idAbs",
                 "type": "string"},
 
-            "alternative_title": {
+            "alternate_title": {
                 "path": "dataIdInfo/idCitation/resAltTitle",
                 "type": "string"},
 


### PR DESCRIPTION
I updated the Supported Items table to include these items that I added to elements.py yesterday: Alternative Title, Identifier Code (1), Identifier Code (2), Identifier Code (3), Identifier Code (4), Metadata File Identifier, Dataset URI, and Resource Label.  I just appended them to the bottom of the table.

In elements.py, I changed 'alternative_title' to 'alternate_title' to be more consistent with the naming in ArcCatalog.

Thanks!