### PR TITLE
Add fallback to arcpy.env.workspace

### DIFF
--- a/arcpy_metadata/metadata_editor.py
+++ b/arcpy_metadata/metadata_editor.py
@@ -273,6 +273,8 @@ class MetadataEditor(object):
                 return workspace
             else:
                 workspace = os.path.dirname(workspace)
+                if workspace == '' and arcpy.env.workspace:
+                    return arcpy.env.workspace
                 desc = arcpy.Describe(workspace)
 
     def get_workspace_type(self):


### PR DESCRIPTION
If a workspace can't be found by parsing the dataset path, but the workspace is set in the arcpy environment, use the environment value for the workspace.